### PR TITLE
Fix connection hanging on linux

### DIFF
--- a/src/Stubbery/ApiStubRequestHandler.cs
+++ b/src/Stubbery/ApiStubRequestHandler.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Stubbery.RequestMatching;
+using System.IO;
 
 namespace Stubbery
 {
@@ -17,13 +18,21 @@ namespace Stubbery
 
         public async Task HandleAsync(HttpContext httpContext)
         {
-            httpContext.Response.StatusCode = StatusCodes.Status404NotFound;
-
-            var firstMatch = configuredEndpoints.FirstOrDefault(e => e.IsMatch(httpContext));
-
-            if (firstMatch != null)
+            using (var bodyStream = new MemoryStream())
             {
-                await firstMatch.SendResponseAsync(httpContext);
+                // Ensure the request body is fully read to avoid hanging connections on linux
+                await httpContext.Request.Body.CopyToAsync(bodyStream);
+                httpContext.Request.Body = bodyStream;
+                bodyStream.Position = 0;
+
+                httpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+
+                var firstMatch = configuredEndpoints.FirstOrDefault(e => e.IsMatch(httpContext));
+
+                if (firstMatch != null)
+                {
+                    await firstMatch.SendResponseAsync(httpContext);
+                }
             }
         }
     }

--- a/src/Stubbery/StreamExtensions.cs
+++ b/src/Stubbery/StreamExtensions.cs
@@ -14,7 +14,7 @@ namespace Stubbery
         /// </summary>
         /// <param name="stream">The stream to read.</param>
         /// <returns>The <see cref="Task" /> representing the asynchronous operation.</returns>
-        public static Task<string> ReadAsStringAsync(this Stream stream)
+        public static async Task<string> ReadAsStringAsync(this Stream stream)
         {
             if (stream == null)
             {
@@ -23,7 +23,7 @@ namespace Stubbery
 
             using (var sr = new StreamReader(stream))
             {
-                return sr.ReadToEndAsync();
+                return await sr.ReadToEndAsync();
             }
         }
 

--- a/src/Stubbery/Stubbery.csproj
+++ b/src/Stubbery/Stubbery.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Library for creating Api stubs in .NET.</Description>
     <Copyright>Copyright � Mark Vincze 2016</Copyright>
-    <VersionPrefix>1.2.4</VersionPrefix>
+    <VersionPrefix>1.2.6</VersionPrefix>
     <Authors>Mark Vincze</Authors>
     <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
     <DebugType>full</DebugType>

--- a/test/Stubbery.IntegrationTests/HangingConnectionTest.cs
+++ b/test/Stubbery.IntegrationTests/HangingConnectionTest.cs
@@ -14,7 +14,7 @@ namespace Stubbery.IntegrationTests
         [Fact]
         public async Task MultiplePosts_OneMatch_DoesntHangConnectionOnLinux()
         {
-            var largeText = string.Join("", Enumerable.Range(0, 1000).Select(x => "abcdefg"));
+            var largeText = new string('a', 6000);
 
             using (var sut = new ApiStub())
             {

--- a/test/Stubbery.IntegrationTests/HangingConnectionTest.cs
+++ b/test/Stubbery.IntegrationTests/HangingConnectionTest.cs
@@ -1,0 +1,40 @@
+﻿using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Stubbery.IntegrationTests
+{
+    public class HangingConnectionTest
+    {
+        private readonly HttpClient httpClient = new HttpClient();
+
+        [Fact]
+        public async Task MultiplePosts_OneMatch_DoesntHangConnectionOnLinux()
+        {
+            var largeText = string.Join("", Enumerable.Range(0, 1000).Select(x => "abcdefg"));
+
+            using (var sut = new ApiStub())
+            {
+                sut.Post("/", (req, args) => "testresponse1");
+
+                sut.Start();
+
+                for (var i = 0; i < 5; i++)
+                {
+                    var postContent = new StringContent(largeText, Encoding.UTF8, "text/plain");
+
+                    var result = await httpClient.PostAsync(sut.Address, postContent);
+
+                    Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+                    var resultString = await result.Content.ReadAsStringAsync();
+
+                    Assert.Equal("testresponse1", resultString);
+                }
+            }
+        }
+    }
+}

--- a/test/Stubbery.IntegrationTests/StreamExtensionsTest.cs
+++ b/test/Stubbery.IntegrationTests/StreamExtensionsTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -11,13 +12,13 @@ namespace Stubbery.IntegrationTests
         [Fact]
         public async Task ReadAsStringAsync_CalledOnNull_ArgumentNullException()
         {
-            await Assert.ThrowsAsync<ArgumentNullException>(() => ((Stream) null).ReadAsStringAsync());
+            await Assert.ThrowsAsync<ArgumentNullException>(() => ((Stream)null).ReadAsStringAsync());
         }
 
         [Fact]
         public async Task ReadAsStringAsync_CalledOnStream_StreamContentReturned()
         {
-            using (var ms = new MemoryStream())
+            using (var ms = new DelayedMemoryStream())
             {
                 var bytes = Encoding.UTF8.GetBytes("TestString");
 
@@ -35,7 +36,7 @@ namespace Stubbery.IntegrationTests
         [Fact]
         public void ReadAsString_CalledOnNull_ArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => ((Stream) null).ReadAsString());
+            Assert.Throws<ArgumentNullException>(() => ((Stream)null).ReadAsString());
         }
 
         [Fact]
@@ -53,6 +54,15 @@ namespace Stubbery.IntegrationTests
                 var result = ms.ReadAsString();
 
                 Assert.Equal("TestString", result);
+            }
+        }
+
+        class DelayedMemoryStream : MemoryStream
+        {
+            public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                await Task.Delay(1);
+                return await base.ReadAsync(buffer, offset, count, cancellationToken);
             }
         }
     }


### PR DESCRIPTION
Our integration tests use Stubbery and they are very flaky on linux because connections hangs from time to time.

After some investigation, I realized it is much more stable if the request body is fully read by Stubbery.