### PR TITLE
Add ability to start the api stub on a custom port

### DIFF
--- a/src/Stubbery/ApiHost.cs
+++ b/src/Stubbery/ApiHost.cs
@@ -26,11 +26,12 @@ namespace Stubbery
             this.startup = startup;
         }
 
-        public string StartHosting()
+        public string StartHosting(int? port)
         {
+            var hostingPort = port ?? PickFreeTcpPort();
             var hostBuilder = new WebHostBuilder()
                 .UseKestrel()
-                .UseUrls($"http://localhost:{PickFreeTcpPort()}/")
+                .UseUrls($"http://localhost:{hostingPort}/")
                 .ConfigureServices(startup.ConfigureServices)
                 .Configure(startup.Configure);
 

--- a/src/Stubbery/ApiStub.cs
+++ b/src/Stubbery/ApiStub.cs
@@ -21,6 +21,30 @@ namespace Stubbery
 
         private string address;
 
+        private int? _port;
+
+        /// <summary>
+        /// Sets the Port for the stub to start />
+        /// </summary>
+        /// <remarks>
+        /// The Post property cannot be set after the stub has already started. The <see cref="Start" /> method needs to be called after the Port is set.
+        /// </remarks>
+        public int? Port
+        {
+            private get
+            {
+                return _port;
+            }
+            set
+            {
+                if (state == ApiStubState.Started)
+                {
+                    throw new InvalidOperationException("The api stub already started on another port. Set the port before the api stub starts.");
+                }
+                _port = value;
+            }
+        }
+
         /// <summary>
         /// Creates a new instance of <see cref="ApiStub" />
         /// </summary>
@@ -68,7 +92,7 @@ namespace Stubbery
                 throw new InvalidOperationException("The api stub is already started.");
             }
 
-            address = apiHost.StartHosting();
+            address = apiHost.StartHosting(Port);
 
             state = ApiStubState.Started;
         }

--- a/src/Stubbery/Stubbery.csproj
+++ b/src/Stubbery/Stubbery.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Library for creating Api stubs in .NET.</Description>
     <Copyright>Copyright � Mark Vincze 2016</Copyright>
-    <VersionPrefix>1.2.6</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <Authors>Mark Vincze</Authors>
     <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
     <DebugType>full</DebugType>

--- a/test/Stubbery.IntegrationTests/CustomConfigTest.cs
+++ b/test/Stubbery.IntegrationTests/CustomConfigTest.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Stubbery.IntegrationTests
+{
+    public class CustomConfigTest
+    {
+        public class CustomPort
+        {
+            private readonly HttpClient httpClient = new HttpClient();
+
+            [Fact]
+            public void Start_StartsStubWithCustomPort_WhenPortIsSet()
+            {
+                using (var apiStub = new ApiStub())
+                {
+                    apiStub.Port = 1010;
+
+                    apiStub.Start();
+
+                    var stubPort = apiStub.Address.Split(':')[2];
+                    Assert.Equal(stubPort, "1010");
+                }
+            }
+
+            [Fact]
+            public void Port_ThrowsInvalidOperationException_WhenBeingSetAndStubAlreadyStarted()
+            {
+                using (var apiStub = new ApiStub())
+                {
+                    apiStub.Start();
+
+                    Assert.Throws<InvalidOperationException>(() => apiStub.Port = 1234);
+                }
+            }
+
+            [Fact]
+            public async Task Get_CallsStubWithCustomPort_WhenCustomPortIsSet()
+            {
+                using (var apiStub = new ApiStub())
+                {
+                    apiStub.Get("/testget", (req, args) => "testresponse");
+                    apiStub.Port = 1020;
+                    apiStub.Start();
+
+                    var result = await httpClient.GetAsync(new UriBuilder(new Uri(apiStub.Address)) { Path = "/testget" }.Uri);
+
+                    Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+                    var resultString = await result.Content.ReadAsStringAsync();
+
+                    Assert.Equal("testresponse", resultString);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I thought this would be a nice feature to have as allows the ability for people to know on which port the stub will be running and that way make it easier to configure the application to use it.

This doesn't introduce any breaking changes so I upgraded the version on the csproj to 1.3.0. Let me know what you think and if possible deploy the new version to nuget so we can use it as soon as possible.