### PR TITLE
Update preconditions.md

### DIFF
--- a/docs/documentation/preconditions.md
+++ b/docs/documentation/preconditions.md
@@ -34,16 +34,6 @@ sut.Get("/testget", (req, args) => "testresponse")
     .IfHeader("Origin", "http://www.example.com");
 ```
 
-## Body
-
-We can specify requirements against the request body by calling the `IfBody` method. 
-
-```csharp
-// Will only respond if the body contains the string "bodyCondition".
-sut.Post("/testget", (req, args) => "testresponse")
-    .IfBody(s => s.ReadAsString().Contains("bodyCondition"));
-```
-
 ## Route
 
 If we only want to respond on a particular path, we can pass a route template to the `Get`, `Post`, `Put` and `Delete` methods, or we can call the `IfRoute` method. 


### PR DESCRIPTION
The IfBody method is no longer available, I noticed this playing around with the library. It is a handy function, just a question what was the motivation for removing this? Possible to reintroduce it? I like the idea of being able to use the following for my posts :-
stub.Post("/api/path/action")
.IfBody(s => s.ReadAsString().Contains("foo") && !s.ReadAsString().Contains("bar"));
.Response((request, args) => "foo response");

stub.Post("/api/path/action")
.IfBody(s => s.ReadAsString().Contains("foo") && s.ReadAsString().Contains("bar"));
.Response((request, args) => "foobar response");