### PR TITLE
Add new condition to filter requests based on body content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,3 +237,6 @@ _Pvt_Extensions
 
 # Coverage reports
 /coverage/
+
+# Rider work dir
+.idea/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.3.0.{build}-{branch}
+version: 1.4.0.{build}-{branch}
 
 skip_tags: true
 

--- a/src/Stubbery/RequestMatching/IConditionSetup.cs
+++ b/src/Stubbery/RequestMatching/IConditionSetup.cs
@@ -69,7 +69,7 @@ namespace Stubbery.RequestMatching
         ISetup IfRoute(string routeTemplate);
         
         /// <summary>
-        /// Sets up a condition so that the stub only responds if the Body satisfy the <paramref name="check" /> condition.
+        /// Sets up a condition so that the stub only responds if the Body satisfies the <paramref name="check" /> condition.
         /// </summary>
         /// <param name="check">The condition the Body has to satisfy.</param>
         /// <returns>The same <see cref="ISetup"/>-instance, so that more conditions can be set fluently.</returns>

--- a/src/Stubbery/RequestMatching/IConditionSetup.cs
+++ b/src/Stubbery/RequestMatching/IConditionSetup.cs
@@ -67,5 +67,12 @@ namespace Stubbery.RequestMatching
         /// </para>
         /// </remarks>
         ISetup IfRoute(string routeTemplate);
+        
+        /// <summary>
+        /// Sets up a condition so that the stub only responds if the Body satisfy the <paramref name="check" /> condition.
+        /// </summary>
+        /// <param name="check">The condition the Body has to satisfy.</param>
+        /// <returns>The same <see cref="ISetup"/>-instance, so that more conditions can be set fluently.</returns>
+        ISetup IfBody(Func<string, bool> check);
     }
 }

--- a/src/Stubbery/RequestMatching/Preconditions/BodyCondition.cs
+++ b/src/Stubbery/RequestMatching/Preconditions/BodyCondition.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.IO;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Internal;
+
+namespace Stubbery.RequestMatching.Preconditions
+{
+    public class BodyCondition : IPrecondition
+    {
+        private readonly Func<string, bool> _condition;
+
+        public BodyCondition(Func<string, bool> condition)
+        {
+            _condition = condition;
+        }
+
+        public bool Match(HttpContext context)
+        {
+            if (context.Request.Body == null)
+            {
+                return false;
+            }
+
+            context.Request.EnableRewind();
+            var reader = new StreamReader(context.Request.Body);
+            var body = reader.ReadToEnd();
+            context.Request.Body.Seek(0, SeekOrigin.Begin);
+            return _condition(body);
+        }
+    }
+}

--- a/src/Stubbery/RequestMatching/Setup.cs
+++ b/src/Stubbery/RequestMatching/Setup.cs
@@ -83,6 +83,13 @@ namespace Stubbery.RequestMatching
             return this;
         }
 
+        public ISetup IfBody(Func<string, bool> check)
+        {
+            orConditions[ConditionGroup.Body].Add(new BodyCondition(check));
+
+            return this;
+        }
+
         public ISetup Response(CreateStubResponse responder)
         {
             if (responder == null)

--- a/src/Stubbery/Stubbery.csproj
+++ b/src/Stubbery/Stubbery.csproj
@@ -1,18 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Description>Library for creating Api stubs in .NET.</Description>
     <Copyright>Copyright � Mark Vincze 2016</Copyright>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <Authors>Mark Vincze</Authors>
     <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
     <DebugType>full</DebugType>
     <AssemblyName>Stubbery</AssemblyName>
     <PackageId>Stubbery</PackageId>
     <PackageTags>ASP.NET;Stub;Testing</PackageTags>
-    <PackageReleaseNotes>Updated to .NET Core RTM</PackageReleaseNotes>
+    <PackageReleaseNotes>Added new condition to filter requests based on body content</PackageReleaseNotes>
     <PackageProjectUrl>http://markvincze.github.io/Stubbery/</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/markvincze/Stubbery/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Libuv" Version="1.9.2" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.2" />
@@ -24,13 +26,16 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
   </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.2" />
   </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <PackageReference Include="System.Net.Http" Version="4.3.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <Reference Include="System" />
   </ItemGroup>
+
 </Project>

--- a/src/Stubbery/Stubbery.csproj
+++ b/src/Stubbery/Stubbery.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <Description>Library for creating Api stubs in .NET.</Description>
     <Copyright>Copyright � Mark Vincze 2016</Copyright>
@@ -14,7 +13,6 @@
     <PackageProjectUrl>http://markvincze.github.io/Stubbery/</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/markvincze/Stubbery/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Libuv" Version="1.9.2" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.2" />
@@ -26,16 +24,13 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.2" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <PackageReference Include="System.Net.Http" Version="4.3.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <Reference Include="System" />
   </ItemGroup>
-
 </Project>

--- a/test/Stubbery.IntegrationTests/BodyConditionTest.cs
+++ b/test/Stubbery.IntegrationTests/BodyConditionTest.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Stubbery.IntegrationTests
+{
+    public class BodyConditionTest
+    {
+        private readonly HttpClient httpClient = new HttpClient();
+
+        [Fact]
+        public async Task IfBody_BodyIsDifferent_NotFoundReturned()
+        {
+            using (var sut = new ApiStub())
+            {
+                sut.Post("/testpost", (req, args) => "testresponse")
+                    .IfBody(body => body.Contains("testpost"));
+                
+                sut.Start();
+
+                var result = await httpClient.PostAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testpost" }.Uri,
+                    new StringContent("testrequest"));
+                
+                Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
+            }
+        }
+        
+        [Fact]
+        public async Task IfBody_BodyIsEqual_ResultReturned()
+        {
+            using (var sut = new ApiStub())
+            {
+                sut.Post("/testpost", (req, args) => "testresponse")
+                    .IfBody(body => body.Contains("testpost"));
+                
+                sut.Start();
+
+                var result = await httpClient.PostAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testpost" }.Uri,
+                    new StringContent("testpost"));
+
+                var resultString = await result.Content.ReadAsStringAsync();
+                
+                Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+                Assert.Equal("testresponse", resultString);
+            }
+        }
+        
+        [Fact]
+        public async Task IfBody_MultipleBodyOneIsEqual_ResultReturned()
+        {
+            using (var sut = new ApiStub())
+            {
+                sut.Post("/testpost", (req, args) => "testresponse")
+                    .IfBody(body => body.Contains("testpost"))
+                    .IfBody(body => body.Contains("posttest"));
+                
+                sut.Start();
+
+                var result = await httpClient.PostAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testpost" }.Uri,
+                    new StringContent("posttest"));
+
+                var resultString = await result.Content.ReadAsStringAsync();
+                
+                Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+                Assert.Equal("testresponse", resultString);
+            }
+        }
+    }
+}

--- a/test/Stubbery.IntegrationTests/Stubbery.IntegrationTests.csproj
+++ b/test/Stubbery.IntegrationTests/Stubbery.IntegrationTests.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net451;netcoreapp1.0</TargetFrameworks>
     <AssemblyName>Stubbery.IntegrationTests</AssemblyName>
@@ -7,17 +8,21 @@
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
     <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net451'">win7-x64</RuntimeIdentifier>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Stubbery\Stubbery.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.10" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+
 </Project>

--- a/test/Stubbery.IntegrationTests/Stubbery.IntegrationTests.csproj
+++ b/test/Stubbery.IntegrationTests/Stubbery.IntegrationTests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>net451;netcoreapp1.0</TargetFrameworks>
     <AssemblyName>Stubbery.IntegrationTests</AssemblyName>
@@ -8,21 +7,17 @@
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
     <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net451'">win7-x64</RuntimeIdentifier>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Stubbery\Stubbery.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.10" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Added a new precondition to be able to filter requests based on the body content. The precodition takes a func which receives the request body as a string so the caller can decide exactly how to match it with the condition. 

Created tests for the condition. 

The body of the request is provided as a stream (FrameRequestStream) by Kestrel and is not seekable by default as it isn't buffered. Needed to enable rewind on it to be able to read it multiple times so that multiple body conditions can be applied to a stub.