### PR TITLE
Switch to EnableBuffering, and make the match methods async

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 2.0.0.{build}-{branch}
 
 skip_tags: true
 
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 clone_depth: 1
 

--- a/releaseDocs.sh
+++ b/releaseDocs.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-export VSINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community"
-export VisualStudioVersion="15.0"
+export VSINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community"
+export VisualStudioVersion="16.0"
 
 docfx ./docs/docfx.json
 

--- a/src/Stubbery/ApiStubRequestHandler.cs
+++ b/src/Stubbery/ApiStubRequestHandler.cs
@@ -19,14 +19,15 @@ namespace Stubbery
         {
             httpContext.Response.StatusCode = StatusCodes.Status404NotFound;
 
-            var firstMatch = configuredEndpoints.FirstOrDefault(e => e.IsMatch(httpContext));
-
-            if (firstMatch != null)
+            foreach (var endpoint in configuredEndpoints)
             {
-                await firstMatch.SendResponseAsync(httpContext);
+                if (await endpoint.IsMatch(httpContext))
+                {
+                    await endpoint.SendResponseAsync(httpContext);
+                    break;
+                }
             }
 
-            // Ensure the request body is fully read to avoid hanging connections on linux
             await httpContext.Request.Body.ReadAsStringAsync();
         }
     }

--- a/src/Stubbery/RequestMatching/Preconditions/AcceptCondition.cs
+++ b/src/Stubbery/RequestMatching/Preconditions/AcceptCondition.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
 namespace Stubbery.RequestMatching.Preconditions
@@ -12,7 +13,7 @@ namespace Stubbery.RequestMatching.Preconditions
             this.condition = condition;
         }
 
-        public bool Match(HttpContext context)
+        public async Task<bool> Match(HttpContext context)
         {
             if (!context.Request.Headers.ContainsKey("Accept"))
             {

--- a/src/Stubbery/RequestMatching/Preconditions/BodyCondition.cs
+++ b/src/Stubbery/RequestMatching/Preconditions/BodyCondition.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 
 namespace Stubbery.RequestMatching.Preconditions
 {
@@ -15,17 +15,17 @@ namespace Stubbery.RequestMatching.Preconditions
             this.condition = condition;
         }
 
-        public bool Match(HttpContext context)
+        public async Task<bool> Match(HttpContext context)
         {
             if (context.Request.Body == null)
             {
                 return false;
             }
 
-            context.Request.EnableRewind();
+            context.Request.EnableBuffering();
             using (var reader = new StreamReader(context.Request.Body, Encoding.UTF8, true, 1024, true))
             {
-                var body = reader.ReadToEnd();
+                var body = await reader.ReadToEndAsync();
                 context.Request.Body.Seek(0, SeekOrigin.Begin);
                 return condition(body);    
             }

--- a/src/Stubbery/RequestMatching/Preconditions/ContentTypeCondition.cs
+++ b/src/Stubbery/RequestMatching/Preconditions/ContentTypeCondition.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
 namespace Stubbery.RequestMatching.Preconditions
@@ -12,6 +13,6 @@ namespace Stubbery.RequestMatching.Preconditions
             this.condition = condition;
         }
 
-        public bool Match(HttpContext context) => condition(context.Request.ContentType);
+        public async Task<bool> Match(HttpContext context) => condition(context.Request.ContentType);
     }
 }

--- a/src/Stubbery/RequestMatching/Preconditions/HeaderCondition.cs
+++ b/src/Stubbery/RequestMatching/Preconditions/HeaderCondition.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
 namespace Stubbery.RequestMatching.Preconditions
@@ -12,6 +13,6 @@ namespace Stubbery.RequestMatching.Preconditions
             this.condition = condition;
         }
 
-        public bool Match(HttpContext context) => condition(context.Request.Headers);
+        public async Task<bool> Match(HttpContext context) => condition(context.Request.Headers);
     }
 }

--- a/src/Stubbery/RequestMatching/Preconditions/IPrecondition.cs
+++ b/src/Stubbery/RequestMatching/Preconditions/IPrecondition.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 
 namespace Stubbery.RequestMatching.Preconditions
 {
     internal interface IPrecondition
     {
-        bool Match(HttpContext context);
+        Task<bool> Match(HttpContext context);
     }
 }

--- a/src/Stubbery/RequestMatching/Preconditions/MethodCondition.cs
+++ b/src/Stubbery/RequestMatching/Preconditions/MethodCondition.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 
 namespace Stubbery.RequestMatching.Preconditions
 {
@@ -11,6 +12,6 @@ namespace Stubbery.RequestMatching.Preconditions
             this.method = method;
         }
 
-        public bool Match(HttpContext context) => context.Request.Method == method;
+        public async Task<bool> Match(HttpContext context) => context.Request.Method == method;
     }
 }

--- a/src/Stubbery/RequestMatching/Preconditions/QueryArgCondition.cs
+++ b/src/Stubbery/RequestMatching/Preconditions/QueryArgCondition.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
 namespace Stubbery.RequestMatching.Preconditions
@@ -14,6 +15,6 @@ namespace Stubbery.RequestMatching.Preconditions
             this.argValue = argValue;
         }
 
-        public bool Match(HttpContext context) => context.Request.Query[argName].Contains(argValue);
+        public async Task<bool> Match(HttpContext context) => context.Request.Query[argName].Contains(argValue);
     }
 }

--- a/src/Stubbery/RequestMatching/Preconditions/RouteCondition.cs
+++ b/src/Stubbery/RequestMatching/Preconditions/RouteCondition.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 
 namespace Stubbery.RequestMatching.Preconditions
@@ -12,7 +13,7 @@ namespace Stubbery.RequestMatching.Preconditions
             this.route = route.TrimStart('/');
         }
 
-        public bool Match(HttpContext context)
+        public async Task<bool> Match(HttpContext context)
         {
             var routeMatcher = new RouteMatcher();
 

--- a/src/Stubbery/Stubbery.csproj
+++ b/src/Stubbery/Stubbery.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Library for creating Api stubs in .NET.</Description>
     <Copyright>Copyright © Mark Vincze 2018</Copyright>
-    <VersionPrefix>2.2.0</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <Authors>Mark Vincze</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <DebugType>full</DebugType>

--- a/test/Stubbery.IntegrationTests/Stubbery.IntegrationTests.csproj
+++ b/test/Stubbery.IntegrationTests/Stubbery.IntegrationTests.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Stubbery.IntegrationTests</AssemblyName>
     <PackageId>Stubbery.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net451'">win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds `netcoreapp3.1` as a second target framework to the test project to make sure we run our tests on both frameworks.

The `EnableRewind()` call was replaced with `EnableBuffering()`, because `EnableRewind()` is in an internal dll, and cause some assembly not found exceptions.

In 3.1 synchronous operations on the Request and Response are not allowed by default, thus these were changed to be Async. This rippled up in the call chains related to request matching.