### PR TITLE
Allow returning IActionResult and auto Complex Type serialize to Json

### DIFF
--- a/src/Stubbery/ApiStubWebAppStartup.cs
+++ b/src/Stubbery/ApiStubWebAppStartup.cs
@@ -14,6 +14,7 @@ namespace Stubbery
 
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddMvc();
         }
 
         public void Configure(IApplicationBuilder app)

--- a/src/Stubbery/Stubbery.csproj
+++ b/src/Stubbery/Stubbery.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Library for creating Api stubs in .NET.</Description>
     <Copyright>Copyright © Mark Vincze 2018</Copyright>
-    <VersionPrefix>2.4.0</VersionPrefix>
+    <VersionPrefix>2.5.0</VersionPrefix>
     <Authors>Mark Vincze</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <DebugType>full</DebugType>
@@ -19,6 +19,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />
   </ItemGroup>
 
 </Project>

--- a/test/Stubbery.IntegrationTests/ResponseParametersTest.cs
+++ b/test/Stubbery.IntegrationTests/ResponseParametersTest.cs
@@ -1,10 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Stubbery.IntegrationTests
@@ -33,7 +38,7 @@ namespace Stubbery.IntegrationTests
         }
 
         [Fact]
-        public async Task ResponseBody_BodySet_BodyReturned()
+        public async Task ResponseBody_BodySet_BodyReturned_StringResponse()
         {
             using (var sut = new ApiStub())
             {
@@ -50,7 +55,51 @@ namespace Stubbery.IntegrationTests
         }
 
         [Fact]
-        public async Task StatusCode_StatusCodeValueSet_StatusCodeReturned()
+        public async Task ResponseBody_BodySet_BodyReturned_ActionResultResponse()
+        {
+            using (var sut = new ApiStub())
+            using (var ms = new MemoryStream())
+            {
+                await ms.WriteAsync(Encoding.UTF8.GetBytes("Test File Data"));
+                ms.Position = 0;
+
+                sut.Get("/testget", (req, args) => new FileStreamResult(ms, "text/plain"));
+
+                sut.Start();
+
+                var result = await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testget" }.Uri);
+
+                var resultContentType = result.Content.Headers.ContentType.MediaType;
+                var resultFileData = await result.Content.ReadAsStringAsync();
+
+                Assert.Equal("text/plain", resultContentType);
+                Assert.Equal("Test File Data", resultFileData);
+            }
+        }
+
+        [Fact]
+        public async Task ResponseBody_BodySet_BodyReturned_ObjectResponse()
+        {
+            using (var sut = new ApiStub())
+            {
+                sut.Get("/testget", (req, args) => new { TestValue = 234, SubObject = new { Value = "Person" } });
+
+                sut.Start();
+
+                var result = await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testget" }.Uri);
+
+                var resultString = await result.Content.ReadAsStringAsync();
+
+                var resultObject = JsonConvert.DeserializeObject<JToken>(resultString);
+
+                Assert.NotNull(resultObject);
+                Assert.Equal(234, resultObject["TestValue"]);
+                Assert.Equal("Person", resultObject["SubObject"]["Value"]);
+            }
+        }
+
+        [Fact]
+        public async Task StatusCode_StatusCodeSet_StatusCodeReturned()
         {
             using (var sut = new ApiStub())
             {


### PR DESCRIPTION
This PR put support for return result that Inherit from IActionResult e.g. FileContentResult etc..
The dependency on  Mvc DI extension is for IActionExecutor which would be used for a lot of different ActionResult's