### PR TITLE
Add the capability to specify the Headers with a lambda (#28)

### DIFF
--- a/src/Stubbery/RequestMatching/IResultSetup.cs
+++ b/src/Stubbery/RequestMatching/IResultSetup.cs
@@ -42,10 +42,24 @@ namespace Stubbery.RequestMatching
         ISetup Header(string header, string value);
 
         /// <summary>
+        /// Sets the function providing a header to be added to the stub response.
+        /// </summary>
+        /// <param name="headerProvider">The function which provides the header based on the request.</param>
+        /// <returns>The same <see cref="ISetup"/>-instance, so that more parameters can be set fluently.</returns>
+        ISetup Header(Func<HttpRequest, RequestArguments, KeyValuePair<string, string>> headerProvider);
+
+        /// <summary>
         /// Sets the given headers to be added to the response.
         /// </summary>
         /// <param name="headers">The headers to be added to the response.</param>
         /// <returns>The same <see cref="ISetup"/>-instance, so that more parameters can be set fluently.</returns>
         ISetup Headers(params KeyValuePair<string, string>[] headers);
+
+        /// <summary>
+        /// Sets the function providing headers to be added to the stub response.
+        /// </summary>
+        /// <param name="headersProvider">The function which provides the headers based on the request.</param>
+        /// <returns>The same <see cref="ISetup"/>-instance, so that more parameters can be set fluently.</returns>
+        ISetup Headers(Func<HttpRequest, RequestArguments, KeyValuePair<string, string>[]> headersProvider);
     }
 }

--- a/src/Stubbery/RequestMatching/Setup.cs
+++ b/src/Stubbery/RequestMatching/Setup.cs
@@ -131,14 +131,28 @@ namespace Stubbery.RequestMatching
 
         public ISetup Headers(params KeyValuePair<string, string>[] headers)
         {
-            setupResponse.Headers.AddRange(headers);
+            setupResponse.HeaderProviders.Add((req, args) => headers);
 
             return this;
         }
 
         public ISetup Header(string header, string value)
         {
-            setupResponse.Headers.Add(new KeyValuePair<string, string>(header, value));
+            setupResponse.HeaderProviders.Add((req, args) => new[] { new KeyValuePair<string, string>(header, value) });
+
+            return this;
+        }
+
+        public ISetup Header(Func<HttpRequest, RequestArguments, KeyValuePair<string, string>> headerProvider)
+        {
+            setupResponse.HeaderProviders.Add((req, args) => new[] { headerProvider(req, args) });
+
+            return this;
+        }
+
+        public ISetup Headers(Func<HttpRequest, RequestArguments, KeyValuePair<string, string>[]> headersProvider)
+        {
+            setupResponse.HeaderProviders.Add(headersProvider);
 
             return this;
         }


### PR DESCRIPTION
Add ability to do this:

#### Add single header
```csharp
sut.Get("/testget", (req, args) => "testresponse")
                    .Header((req, args) => args.Query.testquery == "Success"
                        ? new KeyValuePair<string, string>("HeaderSuccess", "HeaderValueSuccess")
                        : new KeyValuePair<string, string>("HeaderFailure", "HeaderValueFailure"));
```

and

#### Multiple headers
```csharp
sut.Get("/testget", (req, args) => "testresponse")
                   .Headers((req, args) => args.Query.testquery == "Success"
                       ? new[] {
                           new KeyValuePair<string, string>("HeaderSuccess1", "HeaderValueSuccess1"),
                           new KeyValuePair<string, string>("HeaderSuccess2", "HeaderValueSuccess2"),
                       }
                       : new[] {
                           new KeyValuePair<string, string>("HeaderFailure1", "HeaderValueFailure1"),
                           new KeyValuePair<string, string>("HeaderFailure2", "HeaderValueFailure2"),
                       });
```