### PR TITLE
Add the capability to specify the Headers with a lambda

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.0.0.{build}-{branch}
+version: 2.6.0.{build}-{branch}
 
 skip_tags: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 version: 2.6.0.{build}-{branch}
 
 skip_tags: true
+skip_branch_with_pr: true
 
 image: Visual Studio 2019
 

--- a/src/Stubbery/RequestMatching/IResultSetup.cs
+++ b/src/Stubbery/RequestMatching/IResultSetup.cs
@@ -42,10 +42,24 @@ namespace Stubbery.RequestMatching
         ISetup Header(string header, string value);
 
         /// <summary>
+        /// Sets the function providing a header to be added to the stub response.
+        /// </summary>
+        /// <param name="headerProvider">The function which provides the header based on the request.</param>
+        /// <returns>The same <see cref="ISetup"/>-instance, so that more parameters can be set fluently.</returns>
+        ISetup Header(Func<HttpRequest, RequestArguments, KeyValuePair<string, string>> headerProvider);
+
+        /// <summary>
         /// Sets the given headers to be added to the response.
         /// </summary>
         /// <param name="headers">The headers to be added to the response.</param>
         /// <returns>The same <see cref="ISetup"/>-instance, so that more parameters can be set fluently.</returns>
         ISetup Headers(params KeyValuePair<string, string>[] headers);
+
+        /// <summary>
+        /// Sets the function providing headers to be added to the stub response.
+        /// </summary>
+        /// <param name="headersProvider">The function which provides the headers based on the request.</param>
+        /// <returns>The same <see cref="ISetup"/>-instance, so that more parameters can be set fluently.</returns>
+        ISetup Headers(Func<HttpRequest, RequestArguments, KeyValuePair<string, string>[]> headersProvider);
     }
 }

--- a/src/Stubbery/RequestMatching/IResultSetup.cs
+++ b/src/Stubbery/RequestMatching/IResultSetup.cs
@@ -46,20 +46,20 @@ namespace Stubbery.RequestMatching
         /// </summary>
         /// <param name="headerProvider">The function which provides the header based on the request.</param>
         /// <returns>The same <see cref="ISetup"/>-instance, so that more parameters can be set fluently.</returns>
-        ISetup Header(Func<HttpRequest, RequestArguments, KeyValuePair<string, string>> headerProvider);
+        ISetup Header(Func<HttpRequest, RequestArguments, (string, string)> headerProvider);
 
         /// <summary>
         /// Sets the given headers to be added to the response.
         /// </summary>
         /// <param name="headers">The headers to be added to the response.</param>
         /// <returns>The same <see cref="ISetup"/>-instance, so that more parameters can be set fluently.</returns>
-        ISetup Headers(params KeyValuePair<string, string>[] headers);
+        ISetup Headers(params (string, string)[] headers);
 
         /// <summary>
         /// Sets the function providing headers to be added to the stub response.
         /// </summary>
         /// <param name="headersProvider">The function which provides the headers based on the request.</param>
         /// <returns>The same <see cref="ISetup"/>-instance, so that more parameters can be set fluently.</returns>
-        ISetup Headers(Func<HttpRequest, RequestArguments, KeyValuePair<string, string>[]> headersProvider);
+        ISetup Headers(Func<HttpRequest, RequestArguments, (string, string)[]> headersProvider);
     }
 }

--- a/src/Stubbery/RequestMatching/Setup.cs
+++ b/src/Stubbery/RequestMatching/Setup.cs
@@ -129,7 +129,7 @@ namespace Stubbery.RequestMatching
             return this;
         }
 
-        public ISetup Headers(params KeyValuePair<string, string>[] headers)
+        public ISetup Headers((string, string)[] headers)
         {
             setupResponse.HeaderProviders.Add((req, args) => headers);
 
@@ -138,19 +138,19 @@ namespace Stubbery.RequestMatching
 
         public ISetup Header(string header, string value)
         {
-            setupResponse.HeaderProviders.Add((req, args) => new[] { new KeyValuePair<string, string>(header, value) });
+            setupResponse.HeaderProviders.Add((req, args) => new[] { (header, value) });
 
             return this;
         }
 
-        public ISetup Header(Func<HttpRequest, RequestArguments, KeyValuePair<string, string>> headerProvider)
+        public ISetup Header(Func<HttpRequest, RequestArguments, (string, string)> headerProvider)
         {
             setupResponse.HeaderProviders.Add((req, args) => new[] { headerProvider(req, args) });
 
             return this;
         }
 
-        public ISetup Headers(Func<HttpRequest, RequestArguments, KeyValuePair<string, string>[]> headersProvider)
+        public ISetup Headers(Func<HttpRequest, RequestArguments, (string, string)[]> headersProvider)
         {
             setupResponse.HeaderProviders.Add(headersProvider);
 

--- a/src/Stubbery/RequestMatching/Setup.cs
+++ b/src/Stubbery/RequestMatching/Setup.cs
@@ -131,14 +131,28 @@ namespace Stubbery.RequestMatching
 
         public ISetup Headers(params KeyValuePair<string, string>[] headers)
         {
-            setupResponse.Headers.AddRange(headers);
+            setupResponse.HeaderProviders.Add((req, args) => headers);
 
             return this;
         }
 
         public ISetup Header(string header, string value)
         {
-            setupResponse.Headers.Add(new KeyValuePair<string, string>(header, value));
+            setupResponse.HeaderProviders.Add((req, args) => new[] { new KeyValuePair<string, string>(header, value) });
+
+            return this;
+        }
+
+        public ISetup Header(Func<HttpRequest, RequestArguments, KeyValuePair<string, string>> headerProvider)
+        {
+            setupResponse.HeaderProviders.Add((req, args) => new[] { headerProvider(req, args) });
+
+            return this;
+        }
+
+        public ISetup Headers(Func<HttpRequest, RequestArguments, KeyValuePair<string, string>[]> headersProvider)
+        {
+            setupResponse.HeaderProviders.Add(headersProvider);
 
             return this;
         }

--- a/src/Stubbery/RequestMatching/SetupResponseParameters.cs
+++ b/src/Stubbery/RequestMatching/SetupResponseParameters.cs
@@ -12,7 +12,8 @@ namespace Stubbery.RequestMatching
     internal class SetupResponseParameters
     {
         public Func<HttpRequest, RequestArguments, int> StatusCodeProvider { get; set; } = (req, args) => StatusCodes.Status200OK;
-        public ICollection<Func<HttpRequest, RequestArguments, KeyValuePair<string, string>[]>> HeaderProviders { get; set; } = new List<Func<HttpRequest, RequestArguments, KeyValuePair<string, string>[]>>();
+        public ICollection<Func<HttpRequest, RequestArguments, (string, string)[]>> HeaderProviders { get; set; } =
+            new List<Func<HttpRequest, RequestArguments, (string, string)[]>>();
 
         public CreateStubResponse Responder { get; set; }
 
@@ -29,8 +30,9 @@ namespace Stubbery.RequestMatching
 
             foreach (var headerProvider in HeaderProviders) {
                 var headers = headerProvider(httpContext.Request, arguments);
-                foreach (var header in headers) {
-                    httpContext.Response.Headers[header.Key] = header.Value;
+
+                foreach (var (headerName, headerValue) in headers) {
+                    httpContext.Response.Headers[headerName] = headerValue;
                 }
             }
 
@@ -49,14 +51,10 @@ namespace Stubbery.RequestMatching
                 return;
             }
 
-            if (response is object objectResponse)
+            if (response != null)
             {
-                await httpContext.Response.WriteAsync(JsonConvert.SerializeObject(objectResponse));
-                return;
+                await httpContext.Response.WriteAsync(JsonConvert.SerializeObject(response));
             }
-
-            await httpContext.Response.WriteAsync((string)response);
-            return;
         }
     }
 }

--- a/src/Stubbery/Stubbery.csproj
+++ b/src/Stubbery/Stubbery.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <Description>Library for creating Api stubs in .NET.</Description>
-    <Copyright>Copyright © Mark Vincze 2018</Copyright>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <Copyright>Copyright © Mark Vincze 2020</Copyright>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <Authors>Mark Vincze</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <DebugType>full</DebugType>
     <AssemblyName>Stubbery</AssemblyName>
     <PackageId>Stubbery</PackageId>
     <PackageTags>ASP.NET;Stub;Testing</PackageTags>
-    <PackageReleaseNotes>Added the IfQueryArg helper method to set up query string conditions.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added the capability to configure the response headers dynamically.</PackageReleaseNotes>
     <PackageProjectUrl>http://markvincze.github.io/Stubbery/</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/markvincze/Stubbery/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>

--- a/test/Stubbery.IntegrationTests/ResponseParametersTest.cs
+++ b/test/Stubbery.IntegrationTests/ResponseParametersTest.cs
@@ -124,11 +124,11 @@ namespace Stubbery.IntegrationTests
 
                 sut.Start();
 
-                var resultSuccess = await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testget", Query = "?testquery=Success"}.Uri);
+                var resultSuccess = await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testget", Query = "?testquery=Success" }.Uri);
 
                 Assert.Equal(HttpStatusCode.OK, resultSuccess.StatusCode);
 
-                var resultFailure = await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testget", Query = "?testquery=Failure"}.Uri);
+                var resultFailure = await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testget", Query = "?testquery=Failure" }.Uri);
 
                 Assert.Equal(HttpStatusCode.InternalServerError, resultFailure.StatusCode);
             }
@@ -159,16 +159,16 @@ namespace Stubbery.IntegrationTests
             {
                 sut.Get("/testget", (req, args) => "testresponse")
                     .Header((req, args) => args.Query.testquery == "Success"
-                        ? new KeyValuePair<string, string>("HeaderSuccess", "HeaderValueSuccess")
-                        : new KeyValuePair<string, string>("HeaderFailure", "HeaderValueFailure"));
+                        ? ("HeaderSuccess", "HeaderValueSuccess")
+                        : ("HeaderFailure", "HeaderValueFailure"));
 
                 sut.Start();
 
-                var resultSuccess = await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testget", Query = "?testquery=Success"}.Uri);
+                var resultSuccess = await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testget", Query = "?testquery=Success" }.Uri);
 
                 Assert.Equal("HeaderValueSuccess", resultSuccess.Headers.GetValues("HeaderSuccess").First());
 
-                var resultFailure = await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testget", Query = "?testquery=Failure"}.Uri);
+                var resultFailure = await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testget", Query = "?testquery=Failure" }.Uri);
 
                 Assert.Equal("HeaderValueFailure", resultFailure.Headers.GetValues("HeaderFailure").First());
             }
@@ -180,7 +180,7 @@ namespace Stubbery.IntegrationTests
             using (var sut = new ApiStub())
             {
                 sut.Get("/testget", (req, args) => "testresponse")
-                    .Headers(new KeyValuePair<string, string>("Header1", "HeaderValue1"), new KeyValuePair<string, string>("Header2", "HeaderValue2"));
+                    .Headers(("Header1", "HeaderValue1"), ("Header2", "HeaderValue2"));
 
                 sut.Start();
 
@@ -194,26 +194,29 @@ namespace Stubbery.IntegrationTests
         [Fact]
         public async Task Headers_HeadersProviderSet_HeaderReturned()
         {
-            using (var sut = new ApiStub()) {
+            using (var sut = new ApiStub())
+            {
                 sut.Get("/testget", (req, args) => "testresponse")
                    .Headers((req, args) => args.Query.testquery == "Success"
-                       ? new[] {
-                           new KeyValuePair<string, string>("HeaderSuccess1", "HeaderValueSuccess1"),
-                           new KeyValuePair<string, string>("HeaderSuccess2", "HeaderValueSuccess2"),
+                       ? new[]
+                       {
+                           ("HeaderSuccess1", "HeaderValueSuccess1"),
+                           ("HeaderSuccess2", "HeaderValueSuccess2"),
                        }
-                       : new[] {
-                           new KeyValuePair<string, string>("HeaderFailure1", "HeaderValueFailure1"),
-                           new KeyValuePair<string, string>("HeaderFailure2", "HeaderValueFailure2"),
+                       : new[]
+                       {
+                           ("HeaderFailure1", "HeaderValueFailure1"),
+                           ("HeaderFailure2", "HeaderValueFailure2"),
                        });
 
                 sut.Start();
 
-                var resultSuccess = await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testget", Query = "?testquery=Success"}.Uri);
+                var resultSuccess = await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testget", Query = "?testquery=Success" }.Uri);
 
                 Assert.Equal("HeaderValueSuccess1", resultSuccess.Headers.GetValues("HeaderSuccess1").First());
                 Assert.Equal("HeaderValueSuccess2", resultSuccess.Headers.GetValues("HeaderSuccess2").First());
 
-                var resultFailure = await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testget", Query = "?testquery=Failure"}.Uri);
+                var resultFailure = await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testget", Query = "?testquery=Failure" }.Uri);
 
                 Assert.Equal("HeaderValueFailure1", resultFailure.Headers.GetValues("HeaderFailure1").First());
                 Assert.Equal("HeaderValueFailure2", resultFailure.Headers.GetValues("HeaderFailure2").First());


### PR DESCRIPTION
Reworked the PR by @dstj a little bit, changed to tuple literals from `KeyValuePair<K,V>`.

(@dstj, thanks for the submission, and sorry for the very late review and release!)