### PR TITLE
Fix port collision problem

### DIFF
--- a/test/Stubbery.IntegrationTests/ApiStubConcurrencyTests.cs
+++ b/test/Stubbery.IntegrationTests/ApiStubConcurrencyTests.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Stubbery.IntegrationTests
+{
+    public class ApiStubConcurrencyTests
+    {
+        [Fact]
+        public async Task CreateApiStubInstancesInParallel_ShouldNotCausePortCollision()
+        {
+            Task[] stubTasks = Enumerable.Range(1, 1000)
+                .Select(it =>
+                {
+                    return Task.Run(async () =>
+                    {
+                        ApiStub stub = new ApiStub();
+
+                        stub.Start();
+
+                        await Task.Delay(100);
+                    });
+                }).ToArray();
+
+            await Task.WhenAll(stubTasks);
+        }
+    }
+}


### PR DESCRIPTION
use port 0 when no portnumber is specified. Then there's no chance of port collision when ApiStub instances are created / started in parallel.
The time between "FindFreePort" and "Start" can cause the same port number to be returned from "FindFreePort"