### PR TITLE
Fix port collision problem

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.6.0.{build}-{branch}
+version: 2.6.1.{build}-{branch}
 
 skip_branch_with_pr: true
 

--- a/src/Stubbery/ApiHost.cs
+++ b/src/Stubbery/ApiHost.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Linq;
-using System.Net;
-using System.Net.Sockets;
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
 
 namespace Stubbery
 {
@@ -23,11 +21,9 @@ namespace Stubbery
 
         public string StartHosting(int? port)
         {
-            // this one can cause port collission
-            //var hostingPort = port ?? PickFreeTcpPort();
-
-            // this works
+            // If the port was not specified, we pass in 0, in which case ASP.NET picks a random free port.
             var hostingPort = port ?? 0;
+
             var hostBuilder = new WebHostBuilder()
                 .UseKestrel()
                 .UseUrls($"http://127.0.0.1:{hostingPort}/")
@@ -53,14 +49,6 @@ namespace Stubbery
             }
 
             webHost?.Dispose();
-        }
-        private int PickFreeTcpPort()
-        {
-            var l = new TcpListener(IPAddress.Loopback, 0);
-            l.Start();
-            var port = ((IPEndPoint)l.LocalEndpoint).Port;
-            l.Stop();
-            return port;
         }
     }
 }

--- a/src/Stubbery/Stubbery.csproj
+++ b/src/Stubbery/Stubbery.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Library for creating Api stubs in .NET.</Description>
     <Copyright>Copyright © Mark Vincze 2020</Copyright>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <VersionPrefix>2.6.1</VersionPrefix>
     <Authors>Mark Vincze</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <DebugType>full</DebugType>

--- a/test/Stubbery.IntegrationTests/ApiStubConcurrencyTests.cs
+++ b/test/Stubbery.IntegrationTests/ApiStubConcurrencyTests.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Stubbery.IntegrationTests
+{
+    public class ApiStubConcurrencyTests
+    {
+        [Fact]
+        public async Task CreateApiStubInstancesInParallel_ShouldNotCausePortCollision()
+        {
+            Task[] stubTasks = Enumerable.Range(1, 1000)
+                .Select(it =>
+                {
+                    return Task.Run(async () =>
+                    {
+                        ApiStub stub = new ApiStub();
+
+                        stub.Start();
+
+                        await Task.Delay(100);
+                    });
+                }).ToArray();
+
+            await Task.WhenAll(stubTasks);
+        }
+    }
+}


### PR DESCRIPTION
By @jbroumels:
>use port 0 when no portnumber is specified. Then there's no chance of port collision when ApiStub instances are created / started in parallel.
>The time between "FindFreePort" and "Start" can cause the same port number to be returned from "FindFreePort"