### PR TITLE
Add the ability to force a delay before the response

### DIFF
--- a/src/Stubbery/RequestMatching/IResultSetup.cs
+++ b/src/Stubbery/RequestMatching/IResultSetup.cs
@@ -61,5 +61,19 @@ namespace Stubbery.RequestMatching
         /// <param name="headersProvider">The function which provides the headers based on the request.</param>
         /// <returns>The same <see cref="ISetup"/>-instance, so that more parameters can be set fluently.</returns>
         ISetup Headers(Func<HttpRequest, RequestArguments, (string, string)[]> headersProvider);
+
+        /// <summary>
+        /// Introduce a response delay
+        /// </summary>
+        /// <param name="delay">The delay to introduce.</param>
+        /// <returns>The same <see cref="ISetup"/>-instance, so that more parameters can be set fluently.</returns>
+        ISetup Delay(TimeSpan delay);
+
+        /// <summary>
+        /// Introduce a response delay
+        /// </summary>
+        /// <param name="delayProvider">The function which provides the delay based on the request.</param>
+        /// <returns>The same <see cref="ISetup"/>-instance, so that more parameters can be set fluently.</returns>
+        ISetup Delay(Func<HttpRequest, RequestArguments, TimeSpan> delayProvider);
     }
 }

--- a/src/Stubbery/RequestMatching/Setup.cs
+++ b/src/Stubbery/RequestMatching/Setup.cs
@@ -157,6 +157,20 @@ namespace Stubbery.RequestMatching
             return this;
         }
 
+        public ISetup Delay(TimeSpan delay)
+        {
+            setupResponse.DelayProvider = (req, args) => delay;
+
+            return this;
+        }
+
+        public ISetup Delay(Func<HttpRequest, RequestArguments, TimeSpan> delayProvider)
+        {
+            setupResponse.DelayProvider = delayProvider;
+
+            return this;
+        }
+
         public async Task<bool> IsMatch(HttpContext httpContext)
         {
             foreach (var orGroup in orConditions.Where(g => g.Value.Count > 0))

--- a/src/Stubbery/RequestMatching/SetupResponseParameters.cs
+++ b/src/Stubbery/RequestMatching/SetupResponseParameters.cs
@@ -16,6 +16,7 @@ namespace Stubbery.RequestMatching
             new List<Func<HttpRequest, RequestArguments, (string, string)[]>>();
 
         public CreateStubResponse Responder { get; set; }
+        public Func<HttpRequest, RequestArguments, TimeSpan> DelayProvider { get; set; } = null;
 
         public async Task SendResponseAsync(HttpContext httpContext)
         {
@@ -37,6 +38,10 @@ namespace Stubbery.RequestMatching
             }
 
             var response = Responder(httpContext.Request, arguments);
+
+            if (DelayProvider != null) {
+                await Task.Delay(DelayProvider(httpContext.Request, arguments));
+            }
 
             switch (response)
             {

--- a/test/Stubbery.IntegrationTests/ResponseParametersTest.cs
+++ b/test/Stubbery.IntegrationTests/ResponseParametersTest.cs
@@ -218,6 +218,7 @@ namespace Stubbery.IntegrationTests
         {
             using var sut = new ApiStub();
 
+            const int approxSystemClockResolutionInMs = 15;
             const int msDelay = 200;
             sut.Get("/testget", (req, args) => "testresponse")
                .Delay(TimeSpan.FromMilliseconds(msDelay));
@@ -228,7 +229,7 @@ namespace Stubbery.IntegrationTests
             await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testget" }.Uri);
             sw.Stop();
 
-            Assert.InRange(sw.ElapsedMilliseconds, msDelay, 1.5 * msDelay);
+            Assert.InRange(sw.ElapsedMilliseconds, msDelay - approxSystemClockResolutionInMs, 1.5 * msDelay);
         }
 
         [Fact]
@@ -236,6 +237,7 @@ namespace Stubbery.IntegrationTests
         {
             using var sut = new ApiStub();
 
+            const int approxSystemClockResolutionInMs = 15;
             const int msDelay = 200;
             sut.Get("/testget", (req, args) => "testresponse")
                .Delay((req, args) => TimeSpan.FromMilliseconds(msDelay));
@@ -246,7 +248,7 @@ namespace Stubbery.IntegrationTests
             await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address)) { Path = "/testget" }.Uri);
             sw.Stop();
 
-            Assert.InRange(sw.ElapsedMilliseconds, msDelay, 1.5 * msDelay);
+            Assert.InRange(sw.ElapsedMilliseconds, msDelay - approxSystemClockResolutionInMs, 1.5 * msDelay);
         }
     }
 }


### PR DESCRIPTION
Sometimes, we may need to stub a slow response, so I added the ability to introduced a delay:

Fixed delay:
```csharp
const int msDelay = 200;
sut.Get("/testget", (req, args) => "testresponse")
    .Delay(TimeSpan.FromMilliseconds(msDelay));
```

Dynamic delay based on the request:
```csharp
const int msDelay = 200;
sut.Get("/testget", (req, args) => "testresponse")
    .Delay((req, args) => TimeSpan.FromMilliseconds(msDelay));
```
