### PR TITLE
handling template parse failure

### DIFF
--- a/src/Stubbery/RequestMatching/RouteMatcher.cs
+++ b/src/Stubbery/RequestMatching/RouteMatcher.cs
@@ -28,13 +28,30 @@ namespace Stubbery.RequestMatching
                 }
             }
 
-            var template = TemplateParser.Parse(routeTemplate);
+            var (isSuccess, template) = TryParseTemplate(routeTemplate);
+
+            if (!isSuccess)
+            {
+                return null;
+            }
 
             var matcher = new TemplateMatcher(template, GetDefaults(template));
 
             var values = new RouteValueDictionary();
 
             return matcher.TryMatch(requestPath, values) ? values : null;
+        }
+
+        private static (bool IsSuccess, RouteTemplate Template) TryParseTemplate(string routeTemplate)
+        {
+            try
+            {
+                return (true, TemplateParser.Parse(routeTemplate));
+            }
+            catch
+            {
+                return (false, null);
+            }
         }
 
         private RouteValueDictionary GetDefaults(RouteTemplate parsedTemplate)

--- a/test/Stubbery.IntegrationTests/MultipleSetupsTest.cs
+++ b/test/Stubbery.IntegrationTests/MultipleSetupsTest.cs
@@ -49,5 +49,28 @@ namespace Stubbery.IntegrationTests
 
             Assert.Equal("testresponse1", resultString);
         }
+
+        [Fact]
+        public async Task MultipleSetups_OneHasWrongRoute_OthersStillMatch()
+        {
+            using var sut = new ApiStub();
+
+            sut.Get("/testget/one", (req, args) => "testresponse1");
+            sut.Get("/testget//two", (req, args) => "doesn't match");
+            sut.Get("/testget/three", (req, args) => "testresponse3");
+
+            sut.Start();
+
+            var result3 = await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address))
+            {
+                Path = "/testget/three"
+            }.Uri);
+
+            Assert.Equal(HttpStatusCode.OK, result3.StatusCode);
+
+            var resultString = await result3.Content.ReadAsStringAsync();
+
+            Assert.Equal("testresponse3", resultString);
+        }
     }
 }


### PR DESCRIPTION
This ignores invalid routes passed to stubs,
a future improvement could be to add validation at route condition setup,
so that a validation exception is thrown there... 

but this require some other changes here and there i suppose

```csharp
 public RouteCondition(string route)
        {
            this.route = route.TrimStart('/');
        }
```