### PR TITLE
Throw exception if route cannot be parsed

### DIFF
--- a/src/Stubbery/RequestMatching/Preconditions/RouteCondition.cs
+++ b/src/Stubbery/RequestMatching/Preconditions/RouteCondition.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Template;
 
 namespace Stubbery.RequestMatching.Preconditions
 {
@@ -11,6 +12,7 @@ namespace Stubbery.RequestMatching.Preconditions
         public RouteCondition(string route)
         {
             this.route = route.TrimStart('/');
+            TemplateParser.Parse(route);
         }
 
         public async Task<bool> Match(HttpContext context)

--- a/src/Stubbery/RequestMatching/RouteMatcher.cs
+++ b/src/Stubbery/RequestMatching/RouteMatcher.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -32,7 +33,7 @@ namespace Stubbery.RequestMatching
 
             if (!isSuccess)
             {
-                return null;
+                throw new ArgumentException($"unable to parse template {routeTemplate}");
             }
 
             var matcher = new TemplateMatcher(template, GetDefaults(template));

--- a/src/Stubbery/RequestMatching/RouteMatcher.cs
+++ b/src/Stubbery/RequestMatching/RouteMatcher.cs
@@ -28,13 +28,30 @@ namespace Stubbery.RequestMatching
                 }
             }
 
-            var template = TemplateParser.Parse(routeTemplate);
+            var (isSuccess, template) = TryParseTemplate(routeTemplate);
+
+            if (!isSuccess)
+            {
+                return null;
+            }
 
             var matcher = new TemplateMatcher(template, GetDefaults(template));
 
             var values = new RouteValueDictionary();
 
             return matcher.TryMatch(requestPath, values) ? values : null;
+        }
+
+        private static (bool IsSuccess, RouteTemplate Template) TryParseTemplate(string routeTemplate)
+        {
+            try
+            {
+                return (true, TemplateParser.Parse(routeTemplate));
+            }
+            catch
+            {
+                return (false, null);
+            }
         }
 
         private RouteValueDictionary GetDefaults(RouteTemplate parsedTemplate)

--- a/test/Stubbery.IntegrationTests/MultipleSetupsTest.cs
+++ b/test/Stubbery.IntegrationTests/MultipleSetupsTest.cs
@@ -49,5 +49,28 @@ namespace Stubbery.IntegrationTests
 
             Assert.Equal("testresponse1", resultString);
         }
+
+        [Fact]
+        public async Task MultipleSetups_OneHasWrongRoute_OthersStillMatch()
+        {
+            using var sut = new ApiStub();
+
+            sut.Get("/testget/one", (req, args) => "testresponse1");
+            sut.Get("/testget//two", (req, args) => "doesn't match");
+            sut.Get("/testget/three", (req, args) => "testresponse3");
+
+            sut.Start();
+
+            var result3 = await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address))
+            {
+                Path = "/testget/three"
+            }.Uri);
+
+            Assert.Equal(HttpStatusCode.OK, result3.StatusCode);
+
+            var resultString = await result3.Content.ReadAsStringAsync();
+
+            Assert.Equal("testresponse3", resultString);
+        }
     }
 }

--- a/test/Stubbery.IntegrationTests/MultipleSetupsTest.cs
+++ b/test/Stubbery.IntegrationTests/MultipleSetupsTest.cs
@@ -50,27 +50,15 @@ namespace Stubbery.IntegrationTests
             Assert.Equal("testresponse1", resultString);
         }
 
-        [Fact]
-        public async Task MultipleSetups_OneHasWrongRoute_OthersStillMatch()
+        [Theory]
+        [InlineData("/testget//two")]
+        [InlineData(":hey/hello:8080?what")]
+        public void MultipleSetups_OneHasWrongRoute_ThrowsException(string route)
         {
             using var sut = new ApiStub();
 
-            sut.Get("/testget/one", (req, args) => "testresponse1");
-            sut.Get("/testget//two", (req, args) => "doesn't match");
-            sut.Get("/testget/three", (req, args) => "testresponse3");
-
-            sut.Start();
-
-            var result3 = await httpClient.GetAsync(new UriBuilder(new Uri(sut.Address))
-            {
-                Path = "/testget/three"
-            }.Uri);
-
-            Assert.Equal(HttpStatusCode.OK, result3.StatusCode);
-
-            var resultString = await result3.Content.ReadAsStringAsync();
-
-            Assert.Equal("testresponse3", resultString);
+            Assert.Throws<ArgumentException>(() => sut.Get(route, 
+                (req, args) => "doesn't match"));
         }
     }
 }


### PR DESCRIPTION
This throws if aspnet is unable to parse the route as a valid template,
i think this is acceptable as it signals the developer to fix the test setups.

just added a validation in the constructor here:

```csharp
 public RouteCondition(string route)
        {
            this.route = route.TrimStart('/');
            TemplateParser.Parse(route);
        }

```
so this test can be green
```csharp

        [Theory]
        [InlineData("/testget//two")]
        [InlineData(":hey/hello:8080?what")]
        public void MultipleSetups_OneHasWrongRoute_ThrowsException(string route)
        {
            using var sut = new ApiStub();

            Assert.Throws<ArgumentException>(() => sut.Get(route, 
                (req, args) => "doesn't match"));
        }
  ```